### PR TITLE
Fix metrics tikv engine size bytes

### DIFF
--- a/convertor/prom/prometheus.go
+++ b/convertor/prom/prometheus.go
@@ -204,7 +204,8 @@ func checkAlign(matrix model.Matrix) (bool, int) {
 }
 
 
-// the header is the same order in the json file.
+// the header is the same order as the label order in the json file.
+// if the metrics does not have any label, use default value `agg_val`
 func extractHeader(matrix model.Matrix) []string {
 	labelNames := make(model.LabelNames, 0)
 	header := []string{"timestamp"}
@@ -219,11 +220,15 @@ func extractHeader(matrix model.Matrix) []string {
 			}
 			sort.Sort(labelNames)
 		}
-		lvales := make([]string, len(labelNames))
-		for i, lname := range labelNames {
-			lvales[i] = strings.Split(string(sp.Metric[lname]), ":")[0]
+		if len(labelNames) == 0 {
+			header = append(header, "agg_val")
+		}else {
+			lvales := make([]string, len(labelNames))
+			for i, lname := range labelNames {
+				lvales[i] = strings.Split(string(sp.Metric[lname]), ":")[0]
+			}
+			header = append(header, strings.Join(lvales, ":"))
 		}
-		header = append(header, strings.Join(lvales, ":"))
 	}
 	return header
 }

--- a/data-analysis/example/feature_function.yaml
+++ b/data-analysis/example/feature_function.yaml
@@ -1,7 +1,7 @@
 ---
 feature_functions:
   - name: '集群存储数据总量'
-    metrics_name: 'tikv_store_size_bytes:avg_type:capacity' # metrics_name is used to locate the row in feature.csv or feature df.
+    metrics_name: 'tikv_engine_size_bytes:per_instance:agg_val' # metrics_name is used to locate the row in feature.csv or feature df.
     function: expit # expit is a weighted sigmoid function
     min: 0.5
     max: 100
@@ -9,7 +9,7 @@ feature_functions:
     factor: 3
     weight: 1
   - name: '每TiKV平均存储数据量'
-    metrics_name: 'tikv_store_size_bytes:avg_type:capacity' # metrics_name is used to locate the row in feature.csv or feature df.
+    metrics_name: 'tikv_engine_size_bytes:per_instance:agg_val' # metrics_name is used to locate the row in feature.csv or feature df.
     function: expit # expit is a weighted sigmoid function
     min: 0.5
     max: 10

--- a/example/metrics.yaml
+++ b/example/metrics.yaml
@@ -12,6 +12,8 @@ raw:
 cooked:
   - record: tikv_engine_size_bytes:avg_type
     expr: 'avg(tikv_engine_size_bytes) by (type)'
+  - record: tikv_engine_size_bytes:per_instance
+    expr: 'avg(sum(tikv_engine_size_bytes) by (instance))'
   - record: tikv_store_size_bytes:avg_type
     expr: 'avg(tikv_store_size_bytes) by (type)'
   - record: tikv_raftstore_region_count:avg_type

--- a/example/reshape_rules.yaml
+++ b/example/reshape_rules.yaml
@@ -8,3 +8,4 @@ rules:
   - record: tikv_engine_estimate_num_keys:avg_cf_db
   - record: tikv_engine_size_bytes:avg_db_type
   - record: tidb_tikvclient_gc_config
+  - record: tikv_engine_size_bytes:per_instance


### PR DESCRIPTION
Signed-off-by: Shenjun <mashenjun0902@gmail.com>
- use the metrics `tikv_engine_size_bytes ` to calculate current storage size